### PR TITLE
Fix pip installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ napari.manifest =
     napari-nyxus = napari_nyxus:napari.yaml
 
 [options.package_data]
-* = *.yml
+* = *.yaml
 
 [versioneer]
 # Automatic version numbering scheme


### PR DESCRIPTION
- Change package data to use .yaml instead of .yml