### PR TITLE
bugfix: opencl-backed label images were not supported for double-clicking table headers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     pandas
     nyxus>=0.5.0
     imagecodecs
-    napari-skimage-regionprops
+    napari-skimage-regionprops>=0.10.1
 
 [options.entry_points]
 napari.manifest =


### PR DESCRIPTION
Hi @JesseMckinzie ,

this solves the issue described [here](https://github.com/PolusAI/napari-nyxus/issues/3#issuecomment-1554753601). It turned out the bug was in napari-skimage-regionprops and is resolved in [version 0.10.1](https://github.com/haesleinhuepf/napari-skimage-regionprops/releases/tag/0.10.1).

Thanks for the headsup!

Best,
Robert