### PR TITLE
Make screenshots appear on napari-hub.org page

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,43 +56,43 @@ napari
 After installing the plugin, start Napari by running the command `napari` from the command line. Once the Napari 
 GUI is loaded, the Nyxus plugin can be loaded from the `Plugins` menu in the toolbar by going to Plugins -> nyxus-napari.
 
-![](docs/source/img/plugin_menu.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/plugin_menu.png)
 
 A widget will appear in the Napari viewer to run Nyxus.
 
-![](docs/source/img/nyxus_loaded.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/nyxus_loaded.png)
 
 As shown by the example above, Nyxus will take in Intensity and Segmentation images. These parameters can either be a stack
 of images or a single image pair. To load an image pair, use File -> Open File(s)... and select the images to load.
 
-![](docs/source/img/open_image.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/open_image.png)
 
 
 Note that this method can also be used to open a stack of image, by using File -> Open Folder... instead of images. 
 
 If the segmentation is loaded as an Image type in the napari viewer, it must first be converted to the Labels type. The image can converted as shown below.
 
-![](docs/source/img/convert_to_labels.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/convert_to_labels.png)
 
 The loaded files can then be selected with the Intensity and Segmentation drop down menus. Other parameters can also be changed,
 such as which features to calculate. For more information on the available features, see https://nyxus.readthedocs.io/en/latest/featurelist.html.
 
-![](docs/source/img/setup_calculation.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/setup_calculation.png)
 
 After running Nyxus, the feature calculations will also appear in the Napari viewer.
 
-![](docs/source/img/feature_results.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/feature_results.png)
 
 The Nyxus Napari plugin provides functionality to interact with the table containing the feature calculations. First, click on the segmentation image and then select `show selected` in the layer controls. 
 
 
 Then, if a value is clicked in the `label` column of the table, the respective ROI will be highlighted in the segmentation image in the viewer.
 
-![](docs/source/img/click_label.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/click_label.png)
 
 To select the ROI and have it added to a separate Labels image, the label in the table can be double clicked. Each double clicked label will be added to the same Labels image as show below. To unselect, the ROI, double click its respective label again.
 
-![](docs/source/img/double_click_label.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/double_click_label.png)
 
 This feature can also be used in the opposite way, i.e. if an ROI is clicked in the segmentation image, the respective row in the 
 feature table will be highlighted.
@@ -100,13 +100,13 @@ feature table will be highlighted.
 If one of the column headers are double clicked, a colormap will be generated in the Napari viewer showing the values of the features in the clicked
 column. For example, if `Intensity` features are calculated, the `INTEGRATED_INTENSITY` column can be clicked and the colormap will appear.
 
-![](docs/source/img/feature_colormap.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/feature_colormap.png)
 
 Once the colormap is loaded, a slider will appear in the window with the minimum value being the minimum value of the feature colormap and the 
 maximum value of the slider is the maximum value of the colormap. By adjusting the ranges in the slider, a new label image will appear in the viewer
 that contains the ROIs who's features values fall within the slider values.
 
-![](docs/source/img/slider_feature.png)
+![](https://github.com/PolusAI/napari-nyxus/raw/main/docs/source/img/slider_feature.png)
 
 The new labels resulting from the range slider selector can then be used to run Nyxus on by using the labels image as the `Segmentation` parameter.
 


### PR DESCRIPTION
Hi @JesseMckinzie @hsidky ,

I'm just sending a pull-request with absolute links to screenshots in the readme. After merging this and releasing a new version to pypi, the screenshots will show up on the [napari-hub page](https://www.napari-hub.org/plugins/napari-nyxus) of your plugin.

Let me know what you think!

Best,
Robert
